### PR TITLE
Some basic updates

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+[*]
+insert_final_newline = true
+charset = utf-8
+indent_style = space
+indent_size = 2

--- a/composer.json
+++ b/composer.json
@@ -5,13 +5,13 @@
     "parsing",
     "lexer"
   ],
-  "homepage": "http://qntm.org/loco",
+  "homepage": "https://github.com/qntm/loco",
   "require": {
-    "php": ">=5.3.0"
+    "php": ">=5.6.40"
   },
   "require-dev": {
     "squizlabs/php_codesniffer": "^2.3",
-    "jakub-onderka/php-parallel-lint": "0.*"
+    "php-parallel-lint/php-parallel-lint": "^1.3"
   },
   "autoload": {
     "files": [

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -14,4 +14,7 @@
     <rule ref="PSR1.Classes.ClassDeclaration.MultipleClasses">
         <severity>0</severity>
     </rule>
+    <rule ref="Generic.Files.LineEndings">
+        <severity>0</severity>
+    </rule>
 </ruleset>


### PR DESCRIPTION
* Add a `.editorconfig` to enforce the four-space indentation we use.
* Update the `homepage` property to point to the repo, not the page which was abandoned in 2015.
* Update the minimum required level of PHP from 5.3.0 to 5.6.40. Even the latest version of PHP 5.3, 5.3.29, ships with cURL 7.35.0 inside of it, which doesn't support TLS 1.3, which means that attempting to use Composer with it - even the old 2.2 branch of Composer - results in TLS errors when attempting to connect to Packagist and actually retrieve the dependencies. cURL added TLS 1.3 support in version 7.52.0; PHP 5.6.40 ships with cURL 7.59.0. More upgrades will be forthcoming.
* Stop using `jakub-onderka/php-parallel-lint`, which is abandoned, and use `php-parallel-lint/php-parallel-lint`.
* Disable the `Generic.Files.LineEndings` linting rule. I use Windows, CRLF line endings, whereas others may use LF. But this linter appears to have no setting to just enforce the platform-appropriate line ending.